### PR TITLE
Fixed footer to show copyright from site.params.copyright as in config

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,8 +1,8 @@
 <footer class="footer">
   <div class="footer__inner">
-    {{ if $.Site.Copyright }}
+    {{ if $.Site.Params.Copyright }}
       <div class="copyright copyright--user">
-        <span>{{ $.Site.Copyright | safeHTML }}</span>
+        <span>{{ $.Site.Params.Copyright | safeHTML }}</span>
     {{ else }}
       <div class="copyright">
         <span>© {{ now.Year }} Powered by <a href="https://gohugo.io">Hugo</a></span>


### PR DESCRIPTION
The copyright config didn't work as it wasn't being referenced correctly. Fixed the referencing.
<img width="413" alt="image" src="https://github.com/user-attachments/assets/035abce8-5353-41d3-ba8c-07d321e867c4">
