### PR TITLE
Copyright footer is not centered

### DIFF
--- a/assets/css/footer.scss
+++ b/assets/css/footer.scss
@@ -2,6 +2,8 @@
   padding: 40px 0;
   flex-grow: 0;
   opacity: .5;
+  display: flex;
+  justify-content: $centerTheme;
 
   &__inner {
     display: flex;
@@ -24,9 +26,9 @@
     display: flex;
     flex-flow: row wrap;
     flex: 1;
-    align-items: center;
+    align-items: $centerTheme;
     font-size: 1rem;
-    justify-content: center;
+    justify-content: $centerTheme;
 
     &--user {
       margin: auto;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,3 +1,5 @@
+$centerTheme: {{ if $.Site.Params.CenterTheme }}center{{ else }}flex-start{{ end }};
+
 @import "variables";
 
 @import "font";

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,7 +13,8 @@
 
 {{ template "_internal/google_analytics.html" . }}
 
-{{ $defaultStyles := resources.Get "css/style.scss" }}
+{{ $defaultStylesTemplate := resources.Get "css/style.scss" }}
+{{ $defaultStyles := $defaultStylesTemplate | resources.ExecuteAsTemplate "main.scss" .}}
 <!-- Local Theme Variables -->
 {{ if and (isset .Params "color") (not (eq .Params.color "")) }}
   {{ $localColorCss := resources.Get (printf "css/color/%s.scss" .Params.color) }}


### PR DESCRIPTION
fix: now copyright in footer properly align in different combinations of `fullWidthTheme` and `centerTheme`
https://github.com/mirus-ua/hugo-theme-re-terminal/issues/19 
<img width="1207" alt="Знімок екрана 2024-12-22 о 13 04 28" src="https://github.com/user-attachments/assets/cc0b99c5-d48d-4840-bf8e-f9b80900dd7d" />
<img width="1208" alt="Знімок екрана 2024-12-22 о 13 04 12" src="https://github.com/user-attachments/assets/32edcb15-d7ca-4313-b959-e71fe4b415ad" />
