### PR TITLE
fix: tags URL with integers

### DIFF
--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -36,7 +36,7 @@
         {{ if .Params.tags }}
           <span class="post-tags">
             {{ range .Params.tags }}
-            #<a href="{{ (urlize (printf "tags/%s/" . )) | absLangURL }}">
+            #<a href="{{ (urls.JoinPath "tags" (urlize .)) | absLangURL }}">
               {{- . -}}
             </a>&nbsp;
             {{ end }}

--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -36,7 +36,7 @@
         {{ if .Params.tags }}
           <span class="post-tags">
             {{ range .Params.tags }}
-            #<a href="{{ (urls.JoinPath "tags" (urlize .)) | absLangURL }}">
+            #<a href="{{ (urls.JoinPath "tags" (urlize .) "/") | absLangURL }}">
               {{- . -}}
             </a>&nbsp;
             {{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -26,7 +26,7 @@
         {{ if .Params.tags }}
           <span class="post-tags">
             {{ range .Params.tags }}
-            #<a href="{{ (urlize (printf "tags/%s/" . )) | absLangURL }}">
+            #<a href="{{ (urls.JoinPath "tags" (urlize .)) | absLangURL }}">
               {{- . -}}
             </a>&nbsp;
             {{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -26,7 +26,7 @@
         {{ if .Params.tags }}
           <span class="post-tags">
             {{ range .Params.tags }}
-            #<a href="{{ (urls.JoinPath "tags" (urlize .)) | absLangURL }}">
+            #<a href="{{ (urls.JoinPath "tags" (urlize .) "/") | absLangURL }}">
               {{- . -}}
             </a>&nbsp;
             {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -25,7 +25,7 @@
   {{ if .Params.tags }}
     <span class="post-tags">
       {{ range .Params.tags }}
-      #<a href="{{ (urls.JoinPath "tags" (urlize .)) | absLangURL }}">{{ . }}</a>&nbsp;
+      #<a href="{{ (urls.JoinPath "tags" (urlize .) "/") | absLangURL }}">{{ . }}</a>&nbsp;
       {{ end }}
     </span>
   {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -25,7 +25,7 @@
   {{ if .Params.tags }}
     <span class="post-tags">
       {{ range .Params.tags }}
-      #<a href="{{ (urlize (printf "tags/%s/" .)) | absLangURL }}">{{ . }}</a>&nbsp;
+      #<a href="{{ (urls.JoinPath "tags" (urlize .)) | absLangURL }}">{{ . }}</a>&nbsp;
       {{ end }}
     </span>
   {{ end }}

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -25,7 +25,7 @@
         {{ if .Params.tags }}
           <span class="post-tags">
             {{ range .Params.tags }}
-            #<a href="{{ (urlize (printf "tags/%s/" . )) | absLangURL }}">
+            #<a href="{{ (urls.JoinPath "tags" (urlize .)) | absLangURL }}">
               {{- . -}}
             </a>&nbsp;
             {{ end }}

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -25,7 +25,7 @@
         {{ if .Params.tags }}
           <span class="post-tags">
             {{ range .Params.tags }}
-            #<a href="{{ (urls.JoinPath "tags" (urlize .)) | absLangURL }}">
+            #<a href="{{ (urls.JoinPath "tags" (urlize .) "/") | absLangURL }}">
               {{- . -}}
             </a>&nbsp;
             {{ end }}

--- a/layouts/partials/single_basic.html
+++ b/layouts/partials/single_basic.html
@@ -63,7 +63,7 @@ HERE INSERT ANY CUSTOM <script/> or <style/>
 {{ if .Params.tags }}
 <span class="post-tags">
   {{ range .Params.tags }}
-  #<a href="{{ (urls.JoinPath "tags" (urlize .)) | absLangURL }}">{{ . }}</a>&nbsp;
+  #<a href="{{ (urls.JoinPath "tags" (urlize .) "/") | absLangURL }}">{{ . }}</a>&nbsp;
   {{ end }}
 </span>
 {{ end }}

--- a/layouts/partials/single_basic.html
+++ b/layouts/partials/single_basic.html
@@ -63,7 +63,7 @@ HERE INSERT ANY CUSTOM <script/> or <style/>
 {{ if .Params.tags }}
 <span class="post-tags">
   {{ range .Params.tags }}
-  #<a href="{{ (urlize (printf "tags/%s/" .)) | absLangURL }}">{{ . }}</a>&nbsp;
+  #<a href="{{ (urls.JoinPath "tags" (urlize .)) | absLangURL }}">{{ . }}</a>&nbsp;
   {{ end }}
 </span>
 {{ end }}


### PR DESCRIPTION
**Please, test this MR, as it can break existing tags URL.**

# Description

Using integer as tags (e.g. 2025) is supported by hugo, but printf here converts it to `sint2025`.

An easy client-side solution would be to add quotes to the tag `"2025"`, but it's not intuitive.

Instead, we let hugo choose how to do the conversion.

N.B. Other themes sometimes use `{{ $baseurl }}/tags/{{ . | urlize }}`, but removing absLangURL may break websites.

# Tests
## Working tags
- `NoSpace` => `tags/nospace/`
- `Two Words` => `tags/two-words/`
- `2025` => `tags/2025/`
- `2025.1` => `tags/2025.1/`
- `1/2` => `tags/1/2/`
- `✔️` => `tags/%EF%B8%8F/`
- `1\2` => `tags/1%5C2/` ~~IMO we can ignore this case, which can produce other weird behaviors.~~ fixed by 
fcb047a

## Breaking change