### PR TITLE
feature: added adaptive and light versions of all themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,8 +224,13 @@ pagination.pagerSize = 5
   # the list of set content will show up on your index page (baseurl).
   contentTypeName = "posts"
 
+  # any of the colors:
   # ["orange", "blue", "red", "green", "pink", "paper"]
-  themeColor = "orange"
+  # combined with:
+  # * "-dark" for a dark theme
+  # * "-light" for a light theme
+  # * "-dynamic" for a theme that adapts to the browser settings
+  themeColor = "orange-dynamic"
 
   # if you set this to 0, only submenu trigger will be visible
   showMenuItems = 2

--- a/assets/css/color/blue.scss
+++ b/assets/css/color/blue.scss
@@ -1,3 +1,4 @@
 html:root {
-  --accent: #23b0ff;
+  --accent-light: #004166;
+  --accent-dark: #23b0ff;
 }

--- a/assets/css/color/green.scss
+++ b/assets/css/color/green.scss
@@ -1,3 +1,4 @@
 html:root {
-  --accent: #78e2a0;
+  --accent-light: #12542b;
+  --accent-dark: #78e2a0;
 }

--- a/assets/css/color/orange.scss
+++ b/assets/css/color/orange.scss
@@ -1,3 +1,4 @@
 html:root {
-  --accent: #ffa86a;
+  --accent-light: #9e4200;
+  --accent-dark: #ffa86a;
 }

--- a/assets/css/color/paper.scss
+++ b/assets/css/color/paper.scss
@@ -1,3 +1,4 @@
 html:root {
-  --accent: #1d1e28;
+  --accent-light: #1d1e28;
+  --accent-dark: #c4c5d4;
 }

--- a/assets/css/color/pink.scss
+++ b/assets/css/color/pink.scss
@@ -1,3 +1,4 @@
 html:root {
-  --accent: #ee72f1;
+  --accent-light: #5b095d;
+  --accent-dark: #ee72f1;
 }

--- a/assets/css/color/red.scss
+++ b/assets/css/color/red.scss
@@ -1,3 +1,4 @@
 html:root {
-  --accent: #ff6266;
+  --accent-light: #660003;
+  --accent-dark: #ff6266;
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,9 +1,11 @@
 $centerTheme: {{ if $.Site.Params.CenterTheme }}center{{ else }}flex-start{{ end }};
 
-{{ if in (slice "paper") $.Site.Params.ThemeColor }}
+{{ if hasSuffix $.Site.Params.ThemeColor "-light" }}
 @import "variables-light";
+{{ else if hasSuffix $.Site.Params.ThemeColor "-dark" }}
+@import "variables-dark";
 {{ else }}
-@import "variables";
+@import "variables-dynamic";
 {{ end }}
 
 @import "font";

--- a/assets/css/variables-dark.scss
+++ b/assets/css/variables-dark.scss
@@ -1,4 +1,5 @@
 :root {
+  --accent: var(--accent-dark);
   --accent-contrast-color: black;
   --article-link-color: var(inherit);
   --background: color-mix(in srgb, var(--accent) 2%, #1d1e28 98%);

--- a/assets/css/variables-dynamic.scss
+++ b/assets/css/variables-dynamic.scss
@@ -1,0 +1,5 @@
+@import "variables-light";
+
+@media (prefers-color-scheme: dark) {
+  @import "variables-dark";
+}

--- a/assets/css/variables-light.scss
+++ b/assets/css/variables-light.scss
@@ -1,23 +1,24 @@
 :root {
+  --accent: var(--accent-light);
   --accent-contrast-color: white;
   --article-link-color: var(inherit);
-  --background: color-mix(in srgb, var(--accent) 2%, #fefcfa 98%);
+  --background: color-mix(in srgb, var(--accent) 10%, #fefcfa 90%);
   --border-color: rgba(0, 0, 0, 0.1);
   --color: black;
   --menu-color: black;
 
   // Use in code syntax highlighting
-  --syntax-func-color: color-mix(in srgb, var(--accent) 70%, #000 30%);
+  --syntax-func-color: color-mix(in srgb, var(--accent) 90%, #555 10%);
   --syntax-var-color: color-mix(in srgb, var(--accent) 90%, #000);
   --syntax-value-color: color-mix(in srgb, var(--accent), black);
   --syntax-punctuation-color: black;
-  --syntax-comment-color: rgba(0, 0, 0, 0.3);
-  --syntax-line-highlight-mix: color-mix(in srgb, var(--accent) 90%, #000 10%);
+  --syntax-comment-color: rgba(0, 0, 0, 0.5);
+  --syntax-line-highlight-mix: color-mix(in srgb, var(--accent) 90%, #555 10%);
   --syntax-line-highlight-background-color: hsla(336, 20%, 50%, 0.4);
   --syntax-line-highlight-color: hsl(336, 20%, 95%);
   --syntax-line-highlight-box-shadow: black;
   --syntax-code-border-color: rgba(0, 0, 0, 0.1);
-  --syntax-code-copy-button-background: hsla(360, 0%, 87.8%, 0.2);
+  --syntax-code-copy-button-background: hsla(360, 0%, 87.8%, 0.5);
   --syntax-code-copy-button-color: #444;
   --syntax-code-copy-button-box-shadow-color: rgba(255, 255, 255, 0.2);
 }

--- a/demoSite/hugo.toml
+++ b/demoSite/hugo.toml
@@ -5,7 +5,7 @@ pagination.pagerSize = 5
 
 [params]
   contentTypeName = "posts"
-  themeColor = "blue"
+  themeColor = "blue-dynamic"
   showMenuItems = 3
   fullWidthTheme = false
   centerTheme = true

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,15 +16,24 @@
 {{ $defaultStylesTemplate := resources.Get "css/style.scss" }}
 {{ $defaultStyles := $defaultStylesTemplate | resources.ExecuteAsTemplate "main.scss" .}}
 <!-- Local Theme Variables -->
+{{ $.Scratch.Set "color" "orange" }}
 {{ if and (isset .Params "color") (not (eq .Params.color "")) }}
-  {{ $localColorCss := resources.Get (printf "css/color/%s.scss" .Params.color) }}
+  {{ $color := strings.TrimSuffix "-light" .Params.color }}
+  {{ $color := strings.TrimSuffix "-dark" $color }}
+  {{ $color := strings.TrimSuffix "-dynamic" $color }}
+  {{ $.Scratch.Set "color" $color }}
+  {{ $localColorCss := resources.Get (printf "css/color/%s.scss" $color) }}
   {{ $localCss := slice $localColorCss $defaultStyles | resources.Concat (printf "css/%s-local.scss" .Params.color) }}
   {{ $options := (dict "transpiler" "libsass") }}
   {{ $localColorStyles := $localCss | css.Sass $options }}
   <link rel="stylesheet" href="{{ $localColorStyles.Permalink }}">
 {{ else }}
   <!-- Theme Variables -->
-  {{ $colorCss := resources.Get (printf "css/color/%s.scss" ($.Site.Params.ThemeColor | default "blue")) }}
+  {{ $color := strings.TrimSuffix "-light" $.Site.Params.ThemeColor }}
+  {{ $color := strings.TrimSuffix "-dark" $color }}
+  {{ $color := strings.TrimSuffix "-dynamic" $color }}
+  {{ $.Scratch.Set "color" $color }}
+  {{ $colorCss := resources.Get (printf "css/color/%s.scss" $color) }}
   {{ $css := slice $colorCss $defaultStyles | resources.Concat "css/base.scss" }}
   {{ $options := (dict "transpiler" "libsass" "targetPath" "styles.css" "outputStyle" "compressed" "enableSourceMap" true "precision" 6 "includePaths" (slice "node_modules")) }}
   {{ $styles := $css | css.Sass $options }}
@@ -40,8 +49,8 @@
 {{ if isset $.Site.Params "favicon" }}
   <link rel="shortcut icon" href="{{ $.Site.Params.favicon | absURL }}">
 {{ else }}
-  <link rel="shortcut icon" href="{{ printf "img/theme-colors/%s.png" (or .Params.color $.Site.Params.ThemeColor | default "orange") | absURL }}">
-  <link rel="apple-touch-icon" href="{{ printf "img/theme-colors/%s.png" (or .Params.color $.Site.Params.ThemeColor | default "orange") | absURL }}">
+  <link rel="shortcut icon" href="{{ printf "img/theme-colors/%s.png" (or .Params.color ($.Scratch.Get "color")) | absURL }}">
+  <link rel="apple-touch-icon" href="{{ printf "img/theme-colors/%s.png" (or .Params.color ($.Scratch.Get "color")) | absURL }}">
 {{ end }}
 
 <!-- Twitter Card -->
@@ -70,7 +79,7 @@
   {{ if isset $.Site.Params "favicon" }}
     <meta property="og:image" content="{{ $.Site.Params.favicon | absURL }}">
   {{ else }}
-    <meta property="og:image" content="{{ printf "img/favicon/%s.png" $.Site.Params.ThemeColor | absURL }}">
+    <meta property="og:image" content="{{ printf "img/favicon/%s.png" ($.Scratch.Get "color") | absURL }}">
   {{ end }}
 {{ end }}
 <meta property="og:image:width" content="1200">


### PR DESCRIPTION
I have slightly reworked the theme generation to allow automatic generation of light, dark and dynamic themes from all accent colors.
<img width="1446" height="470" alt="Screenshot From 2025-09-30 19-43-53" src="https://github.com/user-attachments/assets/9d34908d-c57e-4a7c-a4c0-bd3190734bb6" />

As color perception at very light / very dark ranges are somewhat different from each other I slightly adapted the light values in `variables-light.scss` to have the same slight color tints as in the dark version.

I'm not particularly used to either css or hugo, so let me know if anything needs changing.

This relates (and probably closes) #10 and #47 .