### PR TITLE
fix: use accent color for dropdown

### DIFF
--- a/assets/css/menu.scss
+++ b/assets/css/menu.scss
@@ -100,6 +100,7 @@
 
   &__dropdown {
     @include menu;
+    color: var(--accent);
 
     .open & {
       display: flex;


### PR DESCRIPTION
This is a silly PR, but I figure every little bit helps, right? 

Dropdown menus don't currently respect the CSS variables.

<img width="147" height="305" alt="image" src="https://github.com/user-attachments/assets/00bfdeec-1594-44e4-96f3-13c480a0835d" />

Like the menu trigger, I think this should use the `--accent` color.

<img width="147" height="305" alt="image" src="https://github.com/user-attachments/assets/3f3c16b2-69d5-4a27-a573-b5888b3d97ba" />

Loving this theme btw. Keep up the good work!